### PR TITLE
ci: Switch build and publish process from Bun to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,13 +20,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
-        run: bun install
+        run: npm install
 
       - name: Run tests
-        run: bun run test
+        run: npm test
 
       - name: Build project
-        run: bun run build:prod
+        run: npm run build:prod
 
       - name: Publish to npm
         run: npm publish


### PR DESCRIPTION
- Replaced Bun commands with npm commands in the GitHub Actions workflow.
- The workflow now installs dependencies, runs tests, builds the project, and publishes to npm using npm.